### PR TITLE
fix clang static analysis about this line reading an uninitialized value

### DIFF
--- a/hmsearch.cc
+++ b/hmsearch.cc
@@ -411,6 +411,7 @@ void HmSearchImpl::get_candidates(
     HmSearchImpl::CandidateMap& candidates)
 {
     uint8_t key[_partition_bytes];
+    memset(key, 0, _partition_bytes);
 
     for (int i = 0; i < _partitions; i++) {
         int psize = _hash_bits - i * _partition_bits;


### PR DESCRIPTION
key[pbit / 8 - pbyte] ^= flip;
